### PR TITLE
Switches to newer Keyboardio repo and directory layout

### DIFF
--- a/docker/builder.docker
+++ b/docker/builder.docker
@@ -40,8 +40,8 @@ RUN curl https://downloads.arduino.cc/arduino-1.8.5-linux64.tar.xz \
 ENV ARDUINO_PATH /opt/arduino-1.8.5
 
 WORKDIR /src/firmware
-RUN git clone https://github.com/keyboardio/Arduino-Boards.git hardware/keyboardio/avr \
-    && cd hardware/keyboardio/avr \
+RUN git clone https://github.com/keyboardio/Kaleidoscope-Bundle-Keyboardio hardware/keyboardio \
+    && cd hardware/keyboardio \
     && make maintainer-update-submodules
 ENV BOARD_HARDWARE_PATH /src/firmware/hardware
 


### PR DESCRIPTION
I noticed that the docker image didn't build anymore when it cloned a fresh repo so I updated the `builder.docker` to reflect the changes in the other Keyboardio repos since this was first created.